### PR TITLE
Fix validateImage

### DIFF
--- a/plugins/oci-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/oci/tasks/traits/ImageAwareTrait.groovy
+++ b/plugins/oci-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/oci/tasks/traits/ImageAwareTrait.groovy
@@ -66,6 +66,7 @@ trait ImageAwareTrait implements PathAware, ProjectAware {
     Image validateImage(ComputeClient client, String compartmentId) {
         ListImagesResponse response = client.listImages(ListImagesRequest.builder()
             .compartmentId(compartmentId)
+            .displayName(img.displayName)
             .build())
         Image image = response.items.find { Image img -> img.displayName == getResolvedImage().get() }
         if (!image) throw new IllegalStateException("Invalid image ${getResolvedImage().get()}")


### PR DESCRIPTION
When calling `client.listImages()`, it's possible that the initial page of image results will not contain the image that you are looking for. It is better to look up the image by the exact display name and validate that it is returned properly.